### PR TITLE
change _insert() to _presave

### DIFF
--- a/seo_meta.module
+++ b/seo_meta.module
@@ -406,9 +406,9 @@ function seo_meta_get_node_data(Node $node) {
 }
 
 /**
- * Implements hook_node_insert().
+ * Implements hook_node_presave().
  */
-function seo_meta_node_insert(Node $node) {
+function seo_meta_node_presave(Node $node) {
 
   if (isset($node->seo_meta['enabled']) && $node->seo_meta['enabled'] == 1) {
     // save OG image as permanent file 


### PR DESCRIPTION
This fixes #19 

I cannot see the reason why the seo_meta_node_presave() function, which acts when node is being inserted AND updated, was changed to seo_meta_node_insert() wich doesn't take place when updating the node. Without this change, og images added during node update doesn't get marked as permanent thus deleted during cron runs.